### PR TITLE
This image exists in the Console chart, so can cause chart upgrade issues.

### DIFF
--- a/clusterImageSets/fast/4.3/img4.3.40-x86_64.yaml
+++ b/clusterImageSets/fast/4.3/img4.3.40-x86_64.yaml
@@ -4,6 +4,6 @@ metadata:
   labels:
     channel: fast
     visible: 'true'
-  name: img4.3.40-x86-64
+  name: img4.3.40-x86-64-appsub
 spec:
   releaseImage: quay.io/openshift-release-dev/ocp-release:4.3.40-x86_64


### PR DESCRIPTION
Before the merge:
![image](https://user-images.githubusercontent.com/20729652/101090805-38838d00-3585-11eb-88ee-062d97403209.png)

From the Cluster Create UI.