### PR TITLE
Deploy open-cluster-management/acm-hive-openshift-releases to github.com/open-cluster-management/acm-hive-openshift-releases.git:main

### DIFF
--- a/clusterImageSets/fast/4.3/img4.3.40-x86_64.yaml
+++ b/clusterImageSets/fast/4.3/img4.3.40-x86_64.yaml
@@ -3,7 +3,7 @@ kind: ClusterImageSet
 metadata:
   labels:
     channel: fast
-    visible: 'true'
+    visible: 'false'
   name: img4.3.40-x86-64-appsub
 spec:
   releaseImage: quay.io/openshift-release-dev/ocp-release:4.3.40-x86_64

--- a/clusterImageSets/fast/4.4/img4.4.33-x86_64.yaml
+++ b/clusterImageSets/fast/4.4/img4.4.33-x86_64.yaml
@@ -3,7 +3,7 @@ kind: ClusterImageSet
 metadata:
   labels:
     channel: fast
-    visible: 'true'
+    visible: 'false'
   name: img4.4.33-x86-64-appsub
 spec:
   releaseImage: quay.io/openshift-release-dev/ocp-release:4.4.33-x86_64

--- a/clusterImageSets/stable/4.3/img4.3.38-x86_64.yaml
+++ b/clusterImageSets/stable/4.3/img4.3.38-x86_64.yaml
@@ -3,7 +3,7 @@ kind: ClusterImageSet
 metadata:
   labels:
     channel: stable
-    visible: 'true'
+    visible: 'false'
   name: img4.3.38-x86-64-appsub
 spec:
   releaseImage: quay.io/openshift-release-dev/ocp-release:4.3.38-x86_64

--- a/clusterImageSets/stable/4.3/img4.3.40-x86_64.yaml
+++ b/clusterImageSets/stable/4.3/img4.3.40-x86_64.yaml
@@ -3,7 +3,7 @@ kind: ClusterImageSet
 metadata:
   labels:
     channel: stable
-    visible: 'true'
+    visible: 'false'
   name: img4.3.40-x86-64-appsub
 spec:
   releaseImage: quay.io/openshift-release-dev/ocp-release:4.3.40-x86_64

--- a/clusterImageSets/stable/4.4/img4.4.32-x86_64.yaml
+++ b/clusterImageSets/stable/4.4/img4.4.32-x86_64.yaml
@@ -3,7 +3,7 @@ kind: ClusterImageSet
 metadata:
   labels:
     channel: stable
-    visible: 'true'
+    visible: 'false'
   name: img4.4.32-x86-64-appsub
 spec:
   releaseImage: quay.io/openshift-release-dev/ocp-release:4.4.32-x86_64

--- a/clusterImageSets/stable/4.4/img4.4.33-x86_64.yaml
+++ b/clusterImageSets/stable/4.4/img4.4.33-x86_64.yaml
@@ -3,7 +3,7 @@ kind: ClusterImageSet
 metadata:
   labels:
     channel: stable
-    visible: 'true'
+    visible: 'false'
   name: img4.4.33-x86-64-appsub
 spec:
   releaseImage: quay.io/openshift-release-dev/ocp-release:4.4.33-x86_64


### PR DESCRIPTION
Signed off by @jnpacker

* Deprecate 4.3 and 4.4 from ClusterImageSets.
* I set the visible: false for the final images
* Travis job no longer scans for 4.3 and 4.4 z stream updates