### PR TITLE
ACM-34644 Fix releaseImage syntax for SHA256 digest format

### DIFF
--- a/tooling/create-ocp-clusterimagesets.py
+++ b/tooling/create-ocp-clusterimagesets.py
@@ -107,7 +107,7 @@ for version in VERSIONS:
                     imgName=tag.replace("_","-")
                     yaml= open("clusterImageSets/releases/" + version + "/" + fileName,"w+")
                     if USE_SHA_ONLY:
-                        releaseImage = "quay.io/openshift-release-dev/ocp-release:" + tagInfo["manifest_digest"]
+                        releaseImage = "quay.io/openshift-release-dev/ocp-release@" + tagInfo["manifest_digest"]
                     else:
                         releaseImage = "quay.io/openshift-release-dev/ocp-release:" + tag
 


### PR DESCRIPTION
URLs should have a `@` character before `sha256`. `:` separates `sha256` from the actual digest value.

https://redhat.atlassian.net/browse/ACM-34644