### PR TITLE
fix ClusterImageSet digest format erro; enhance clusterImageSet valid…

### DIFF
--- a/.github/workflows/cron-sync-imageset.yml
+++ b/.github/workflows/cron-sync-imageset.yml
@@ -281,6 +281,8 @@ jobs:
         run: make sync-images-job
         env:
           TARGET_BRANCH: backplane-2.17
+      - name: validate-imagesets
+        run: make validate-images
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/post-submit-imageset.yml
+++ b/.github/workflows/post-submit-imageset.yml
@@ -269,6 +269,8 @@ jobs:
         run: make sync-images-job
         env:
           TARGET_BRANCH: backplane-2.17
+      - name: validate-imagesets
+        run: make validate-images
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/tooling/add-branch.py
+++ b/tooling/add-branch.py
@@ -94,6 +94,8 @@ def generate_cron_job_block(branch_name):
         run: make sync-images-job
         env:
           TARGET_BRANCH: {branch_name}
+      - name: validate-imagesets
+        run: make validate-images
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
@@ -118,6 +120,8 @@ def generate_post_submit_job_block(branch_name):
         run: make sync-images-job
         env:
           TARGET_BRANCH: {branch_name}
+      - name: validate-imagesets
+        run: make validate-images
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/tooling/create-ocp-clusterimagesets.py
+++ b/tooling/create-ocp-clusterimagesets.py
@@ -107,7 +107,7 @@ for version in VERSIONS:
                     imgName=tag.replace("_","-")
                     yaml= open("clusterImageSets/releases/" + version + "/" + fileName,"w+")
                     if USE_SHA_ONLY:
-                        releaseImage = "quay.io/openshift-release-dev/ocp-release:" + tagInfo["manifest_digest"]
+                        releaseImage = "quay.io/openshift-release-dev/ocp-release@" + tagInfo["manifest_digest"]
                     else:
                         releaseImage = "quay.io/openshift-release-dev/ocp-release:" + tag
 

--- a/tooling/validate-imagesets.py
+++ b/tooling/validate-imagesets.py
@@ -48,6 +48,8 @@ TAG_PATTERN = re.compile(r"^[\w][\w.\-]*$")
 IMAGE_WITH_SHA = re.compile(r"^quay\.io/openshift-release-dev/ocp-release@(sha256:[a-f0-9]{64})$")
 IMAGE_WITH_TAG = re.compile(r"^quay\.io/openshift-release-dev/ocp-release:([\w][\w.\-]*)$")
 IMAGE_WITH_TAG_AND_SHA = re.compile(r"^quay\.io/openshift-release-dev/ocp-release:([\w][\w.\-]*)@(sha256:[a-f0-9]{64})$")
+# Detects the common mistake of writing :sha256: instead of @sha256:
+IMAGE_COLON_DIGEST = re.compile(r"^quay\.io/openshift-release-dev/ocp-release:(sha256:[a-f0-9]{64})$")
 
 
 class ValidationResult:
@@ -124,6 +126,11 @@ def validate_yaml_structure(file_path):
     elif tag_match:
         result.image_ref = tag_match.group(1)
         result.image_type = 'tag'
+    elif IMAGE_COLON_DIGEST.match(release_image):
+        result.add_error(
+            f"Invalid releaseImage format: {release_image} — "
+            f"digest separator must be '@', not ':' (use ...ocp-release@sha256:... )"
+        )
     else:
         result.add_error(f"Invalid releaseImage format: {release_image}")
 


### PR DESCRIPTION
…ation for release-2.17 and above

The PR addresses the following

- ClusterImageSet  URLs should have a @ character before sha256. : separates sha256 from the actual digest value.
- add clusterImageSet validation for release-2.17 branch cron jobs
- update the add-branch tooling script to make sure the validation is implemented when creating new branches in the future.

https://redhat.atlassian.net/browse/ACM-34644